### PR TITLE
default to config backend

### DIFF
--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -157,6 +157,29 @@ func Server(cfg *config.Config) *cli.Command {
 						SSHKeyAttr:  cfg.Backend.SSHKeyAttr,
 						UseGraphAPI: cfg.Backend.UseGraphAPI,
 					},
+					// TODO read users for the config backend from config file
+					Users: []glauthcfg.User{
+						glauthcfg.User{
+							Name:         "admin",
+							UnixID:       20000,
+							PrimaryGroup: 30000,
+							Mail:         "admin@example.com",
+							PassSHA256:   "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918", // admin
+						},
+						glauthcfg.User{
+							Name:         "demo",
+							UnixID:       20001,
+							PrimaryGroup: 30000,
+							Mail:         "demo@example.com",
+							PassSHA256:   "2a97516c354b68848cdbd8f54a226a0a55b21ed138e207ad6c5cbb9c00aa5aea", // demo
+						},
+					},
+					Groups: []glauthcfg.Group{
+						glauthcfg.Group{
+							Name:   "users",
+							UnixID: 30000,
+						},
+					},
 				}
 				server, err := glauth.NewServer(
 					glauth.Logger(log),

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -162,7 +162,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 
 		&cli.StringFlag{
 			Name:        "backend-datastore",
-			Value:       "owncloud",
+			Value:       "config",
 			Usage:       "datastore to use as the backend. one of config, ldap or owncloud",
 			EnvVars:     []string{"GLAUTH_BACKEND_DATASTORE"},
 			Destination: &cfg.Backend.Datastore,


### PR DESCRIPTION
- adds two hardcoded users: demo & admin
- defaults to the config backend intstead of ldap