### PR TITLE
Bugfix: ignore case when comparing objectclass values

### DIFF
--- a/changelog/unreleased/ignore-case-for-objectclass-value.md
+++ b/changelog/unreleased/ignore-case-for-objectclass-value.md
@@ -1,0 +1,5 @@
+Bugfix: ignore case when comparing objectclass values
+
+The LDAP equality comparison is specified as case insensitive. We fixed the comparison for objectclass properties.
+
+https://github.com/owncloud/ocis-glauth/pull/26

--- a/pkg/server/glauth/handler.go
+++ b/pkg/server/glauth/handler.go
@@ -305,7 +305,7 @@ func parseFilter(f *ber.Packet) (qtype queryType, q string, err error) {
 		// replace attributes
 		switch attribute {
 		case "objectclass":
-			switch value {
+			switch strings.ToLower(value) {
 			case "posixaccount", "shadowaccount", "users", "person", "inetorgperson", "organizationalperson":
 				qtype = usersQuery
 			case "posixgroup", "groups":


### PR DESCRIPTION
The LDAP equality comparison is specified as case insensitive. We fixed the comparison for objectclass properties.