### PR TITLE
handle ownCloudUUID attribute

### DIFF
--- a/changelog/unreleased/handle-ownclouduuid.md
+++ b/changelog/unreleased/handle-ownclouduuid.md
@@ -1,0 +1,6 @@
+Enhancement: handle ownCloudUUID attribute
+
+Clients can now query an accounts immutable id by using the [new `ownCloudUUID` attribute](https://github.com/butonic/owncloud-ldap-schema/blob/master/owncloud.schema#L28-L34).
+
+
+https://github.com/owncloud/ocis-glauth/pull/27


### PR DESCRIPTION
Clients can now query an accounts immutable id by using the [new `ownCloudUUID` attribute](https://github.com/butonic/owncloud-ldap-schema/blob/master/owncloud.schema#L28-L34).

Test using
```console
# ldapsearch -x -H ldap://localhost:9125 -b dc=example,dc=org -D "cn=reva,dc=example,dc=org" -w reva '(&(objectclass=posixAccount)(ownCloudUUID=4c510ada-c86b-4815-8820-42cdf82c3d51))'
```