### PR TITLE
return invalid credentials when user was not found

### DIFF
--- a/changelog/unreleased/fix-bind-when-not-found.md
+++ b/changelog/unreleased/fix-bind-when-not-found.md
@@ -1,0 +1,5 @@
+Bugfix: return invalid credentials when user was not found
+
+We were relying on an error code of the ListAccounts call when the username and password was wrong. But the list will be empty if no user with the given login was found. So we also need to check if the list of accounts is empty.
+
+https://github.com/owncloud/ocis-glauth/pull/30

--- a/pkg/server/glauth/handler.go
+++ b/pkg/server/glauth/handler.go
@@ -64,14 +64,14 @@ func (h ocisHandler) Bind(bindDN, bindSimplePw string, conn net.Conn) (ldap.LDAP
 	userName := strings.TrimPrefix(parts[0], "cn=")
 
 	// check password
-	_, err := h.as.ListAccounts(context.TODO(), &accounts.ListAccountsRequest{
+	res, err := h.as.ListAccounts(context.TODO(), &accounts.ListAccountsRequest{
 		//Query: fmt.Sprintf("username eq '%s'", username),
 		// TODO this allows lookung up users when you know the username using basic auth
 		// adding the password to the query is an option but sending the sover the wira a la scim seems ugly
 		// but to set passwords our accounts need it anyway
 		Query: fmt.Sprintf("login eq '%s' and password eq '%s'", userName, bindSimplePw),
 	})
-	if err != nil {
+	if err != nil || len(res.Accounts) == 0 {
 		h.log.Error().
 			Str("username", userName).
 			Str("binddn", bindDN).


### PR DESCRIPTION
We were relying on an error code of the ListAccounts call when the username and password was wrong. But the list will be empty if no user with the given login was found. So we also need to check if the list of accounts is empty.