### PR TITLE
fix LDAP substring startswith filters

### DIFF
--- a/changelog/unreleased/fix-startswith-queries.md
+++ b/changelog/unreleased/fix-startswith-queries.md
@@ -1,0 +1,5 @@
+Bugfix: fix LDAP substring startswith filters
+
+Filters like `(mail=mar*)` are currentld not parsed correctly, but they are used when searching for recipients. This PR correctly converts them to odata filters like `startswith(mail,'mar')`.
+
+https://github.com/owncloud/ocis-glauth/pull/31


### PR DESCRIPTION
Filters like `(mail=mar*)` are currentld not parsed correctly, but they are used when searching for recipients. This PR correctly converts them to odata filters like `startswith(mail,'mar')`.

ocis-accounts should already suppert phraseprefix bleve queries for odata `startswith` filters: https://github.com/owncloud/ocis-accounts/blob/master/pkg/provider/bleve.go#L29-L41

but  I may not understand how to get phrase prefix queries working, yet ...
```json
2020-07-31T17:39:27+02:00 DBG using query query={"conjuncts":[{"field":"bleve_type","term":"account"},{"disjuncts":[{"disjuncts":[{"field":"on_premises_sam_account_name","prefix":"'mar'"},{"field":"display_name","prefix":"'mar'"}],"min":0},{"field":"mail","prefix":"'mar'"}],"min":0}]} service=accounts
2020-07-31T17:39:27+02:00 DBG result result={"facets":null,"hits":[],"max_score":0,"request":{"explain":false,"facets":null,"fields":null,"from":0,"highlight":null,"includeLocations":false,"query":{"conjuncts":[{"field":"bleve_type","term":"account"},{"disjuncts":[{"disjuncts":[{"field":"on_premises_sam_account_name","prefix":"'mar'"},{"field":"display_name","prefix":"'mar'"}],"min":0},{"field":"mail","prefix":"'mar'"}],"min":0}]},"search_after":null,"search_before":null,"size":10,"sort":["-_score"]},"status":{"failed":0,"successful":1,"total":1},"took":38689,"total_hits":0} service=accounts
```

but on the cli it works:

```
../bleve/bleve query /var/tmp/ocis-accounts/index.bleve "mar" -t prefix -f on_premises_sam_account_name
1 matches, showing 1 through 1, took 546.089µs
    1. f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c (3.351375)
        on_premises_sam_account_name
                marie
```